### PR TITLE
add apiPath to Clowdapp

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -21,6 +21,7 @@ objects:
       webServices:
         public:
           enabled: true
+          apiPath: rhsm
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         args:


### PR DESCRIPTION
This will make sure the `Route` generated by Clowder is created as `/api/rhsm` instead of the generated `/api/rhsm-api-proxy`. Once this is merged the containerized frontend should be good to go. 