### PR TITLE
Add passive health check for reverse_proxy. Update to go 1.21.4

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,8 +3,8 @@ LABEL maintainer=teamnado-ops@redhat.com
 
 ENV GODIR=/usr/local/go APPDIR=/opt/app CGO_ENABLED=0
 
-RUN curl -sfL --retry 10 -o /tmp/go.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz && \
-    echo "b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae /tmp/go.tar.gz" | sha256sum -c && \
+RUN curl -sfL --retry 10 -o /tmp/go.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz && \
+    echo "73cac0215254d0c7d1241fa40837851f3b9a8a742d0b54714cbdfb3feaf8f0af /tmp/go.tar.gz" | sha256sum -c && \
     mkdir -p $GODIR && \
     tar --strip-components=1 -zxf /tmp/go.tar.gz --directory $GODIR && \
     rm /tmp/go.tar.gz && \

--- a/config/local.json
+++ b/config/local.json
@@ -30,7 +30,7 @@
                   "handler": "reverse_proxy",
                   "upstreams": [
                     {
-                      "dial": "echo-api.3scale.net:443"
+                      "dial": "echo-api.3scale.net:7443"
                     }
                   ],
                   "headers": {
@@ -45,6 +45,12 @@
                     "protocol": "http",
                     "tls": {},
                     "response_header_timeout": "60s"
+                  },
+                  "health_checks": {
+                    "passive": {
+                      "fail_duration": "60s",
+                      "max_fails": 3
+                    }
                   }
                 }
               ]

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -119,6 +119,12 @@ objects:
                             "client_certificate_key_file": "/tls/keypair.pem"
                           },
                           "response_header_timeout": "60s"
+                        },
+                        "health_checks": {
+                          "passive": {
+                            "fail_duration": "90s",
+                            "max_fails": 3
+                          }
                         }
                       }
                     ]


### PR DESCRIPTION
This PR enables checking reverse_proxy targets based on the passive health check feature.

I investigated using an active health check, but it doesn't re-use the tls settings (and thus client certificate) from the reverse_proxy settings, and so won't catch one of the big problem items (expired certs).

This has the downside of a bunch of bad client requests making the proxy think the backend is down and temporarily stopping request flow.